### PR TITLE
API error keeps raw data for the underlying server error (if any)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,18 +7,11 @@ let package = Package(
     name: "IndiceNetworkClient",
     platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "IndiceNetworkClient",
             targets: ["IndiceNetworkClient"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "IndiceNetworkClient",
             dependencies: []),

--- a/Sources/IndiceNetworkClient/Models/APIError.swift
+++ b/Sources/IndiceNetworkClient/Models/APIError.swift
@@ -9,39 +9,37 @@ import Foundation
 
 public struct APIError: LocalizedError {
     
-    public struct SimpleError: NetworkError {
-        public let status: Int?
-        public let description: String
+    public static let Unknown         = APIError(description: "Unknown Error", code: nil)
+    public static let Unauthenticated = APIError(description: "Unauthenticated", code: nil)
+    public static let InvalidResponse = APIError(description: "Invalid HttpResponse from server", code: nil)
+    
+
+    public let errorDescription: String
+    public let statusCode: Int?
+    
+    public let raw: Data?
+    
+    public init(description: String, code: Int?, data: Data? = nil) {
+        self.errorDescription = description
+        self.statusCode = code
+        self.raw = data
     }
     
-    public static let Unknown         = APIError(description: "Unknown Error")
-    public static let Unauthenticated = APIError(description: "Unauthenticated")
-    
-    public let errorData: NetworkError
-    
-    public init(description: String, code: Int? = nil) {
-        self.init(errorData: SimpleError(status: code, description: description))
+    public init(response: HTTPURLResponse, data: Data?) {
+        self.init(description: response.description,
+                  code: response.statusCode,
+                  data: data)
     }
-    
-    public init(description: String) {
-        self.init(description: description, code: nil)
-    }
-    
-    public init(errorData: NetworkError) {
-        self.errorData = errorData
-    }
-    
-    public init<T: NetworkError>(response: HTTPURLResponse, withData data: Data?, type: T.Type) {
-        if let errorData = data {
-            if let problemDetails = try? JSONDecoder().decode(type, from: errorData) {
-                self.init(errorData: problemDetails)
-                return
-            }
-            if let errorDescription = String(data: errorData, encoding: .utf8) {
-                self.init(description: errorDescription, code: response.statusCode)
-                return
+
+    func getError<T: Decodable>(using decoder: DecoderProtocol?) -> T? {
+        if let errorData = raw {
+            if let decoder = decoder {
+                return try? decoder.decode(data: errorData)
+            } else {
+                return try? JSONDecoder().decode(T.self, from: errorData)
             }
         }
-        self.init(description: response.description, code: response.statusCode)
+        
+        return nil
     }
 }

--- a/Sources/IndiceNetworkClient/Models/ProblemDetails.swift
+++ b/Sources/IndiceNetworkClient/Models/ProblemDetails.swift
@@ -14,23 +14,26 @@ public protocol NetworkError: Codable {
 
 public struct ProblemDetails: NetworkError {
     
+    static let defaultErrorText = "Unknown Business Error Occurred"
+    
     public let detail: String?
     public let errors: [String:[String]]?
     public let status: Int?
     public let title: String?
     public let type: String?
+    public let code: String?
     
     public let error_description: String?
     
-    // Conformance to ServerError Protocol
+    // Conformance to NetworkError Protocol
     public var description: String {
         get {
             if let existingErrors = errors {
-                return existingErrors.flatMap { (key: String, value: [String] ) -> [String] in
-                    value
-                }.joined(separator: "\n")
+                return existingErrors
+                    .flatMap { $0.value }
+                    .joined(separator: "\n")
             }
-            return detail ?? error_description ?? "Unknown Business Error Occurred"
+            return detail ?? error_description ?? ProblemDetails.defaultErrorText
         }
     }
 }

--- a/Sources/IndiceNetworkClient/Protocols/DecoderProtocol.swift
+++ b/Sources/IndiceNetworkClient/Protocols/DecoderProtocol.swift
@@ -9,7 +9,6 @@ import Foundation
 
 public protocol DecoderProtocol {
     func decode<T: Decodable>(data: Data) throws -> T
-    func decodeError(response: HTTPURLResponse, data: Data) throws -> APIError
 }
 
 
@@ -31,14 +30,6 @@ public class DefaultDecoder: DecoderProtocol {
             return String(decoding: data, as: UTF8.self) as! T
         default:
             return try defaultJSONDecoder.decode(T.self, from: data)
-        }
-    }
-    
-    public func decodeError(response: HTTPURLResponse, data: Data) throws -> APIError {
-        do {
-            return APIError(errorData: try defaultJSONDecoder.decode(ProblemDetails.self, from: data))
-        } catch {
-            return APIError(description: String(data: data, encoding: .utf8)!, code: response.statusCode)
         }
     }
     


### PR DESCRIPTION
APIError can now keep the raw data from the server error it was originated from. Added a getter method that tries to deserialize the rawData to the receiver's concrete type.

Some cleanup/typos.